### PR TITLE
speedups using hashset lookup and caching edges()

### DIFF
--- a/GeometryEx/Comparers.cs
+++ b/GeometryEx/Comparers.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using Elements.Geometry;
+
+// TODO remove this whole file after upgrading to Elements 9.2
+namespace GeometryEx
+{
+    public static class TemporaryVector3Extensions
+    {
+        public static Vector3 Rounded(this Vector3 point, double precision)
+        {
+            return new Vector3(Math.Round(point.X / precision) * precision, Math.Round(point.Y / precision) * precision, Math.Round(point.Z / precision) * precision);
+        }
+
+        public static int GetHashCode(this Vector3 point, double precision)
+        {
+            var alt = 17;
+            var rounded = point.Rounded(precision);
+            alt = alt * 23 + rounded.X.GetHashCode();
+            alt = alt * 23 + rounded.Y.GetHashCode();
+            alt = alt * 23 + rounded.Z.GetHashCode();
+            return alt;
+        }
+    }
+
+
+    public class Vector3Comparer : EqualityComparer<Vector3>
+    {
+        private double _precision = Vector3.EPSILON;
+        /// <summary>
+        /// Construct a Vector3Comparer, specify a tolerance if you want something other than the default Vector3 tolerance.
+        /// </summary>
+        public Vector3Comparer(double precision = Vector3.EPSILON)
+        {
+            _precision = precision;
+        }
+
+        /// <summary>
+        /// Are the two Vector3 geometrically equal within the tolerance.
+        /// </summary>
+        public override bool Equals(Vector3 x, Vector3 y)
+        {
+            return x.IsAlmostEqualTo(y, _precision);
+        }
+
+        /// <summary>
+        /// Get a hashcode for the Vector3 object.
+        /// </summary>
+        public override int GetHashCode(Vector3 vector)
+        {
+            return vector.GetHashCode();
+        }
+    }
+    public class LineComparer : IEqualityComparer<Line>
+    {
+        private double _precision = 5;
+        private bool _directionIndependent = true;
+
+        public LineComparer(double precision = Vector3.EPSILON, bool directionIndependent = true)
+        {
+            _precision = precision;
+            _directionIndependent = directionIndependent;
+        }
+
+        public bool Equals(Line x, Line y)
+        {
+            return (x.Start.IsAlmostEqualTo(y.Start, _precision) && x.End.IsAlmostEqualTo(y.End, _precision))
+                    || (_directionIndependent
+                        && (x.Start.IsAlmostEqualTo(y.End) && x.End.IsAlmostEqualTo(y.Start)));
+        }
+
+        public int GetHashCode(Line obj)
+        {
+            // If the direction doesn't matter, then we always sort the ends by distance from origin just to have a consistent basis
+            if (_directionIndependent
+                && Math.Abs(obj.Start.X) + Math.Abs(obj.Start.Y) + Math.Abs(obj.Start.Z) >
+                   Math.Abs(obj.End.X) + Math.Abs(obj.End.Y) + Math.Abs(obj.End.Z))
+            {
+                obj = obj.Reversed();
+            }
+            int hash = 17;
+            hash = hash * 23 + obj.Start.Rounded(_precision).GetHashCode();
+            hash = hash * 23 + obj.End.Rounded(_precision).GetHashCode();
+            return hash;
+        }
+    }
+
+    public class TriangleComparer : IEqualityComparer<Triangle>
+    {
+        private bool _rotationIndependent = false;
+        private double _precision = Vector3.EPSILON;
+        public TriangleComparer(bool rotationIndependent = false, double precision = Vector3.EPSILON)
+        {
+            _rotationIndependent = rotationIndependent;
+            _precision = precision;
+        }
+        public bool Equals(Triangle x, Triangle y)
+        {
+            if (_rotationIndependent)
+            {
+                return x.IsEqualTo(y);
+            }
+            else
+            {
+                return x.Vertices[0].Position.IsAlmostEqualTo(y.Vertices[0].Position, _precision)
+                    && x.Vertices[1].Position.IsAlmostEqualTo(y.Vertices[1].Position, _precision)
+                    && x.Vertices[2].Position.IsAlmostEqualTo(y.Vertices[2].Position, _precision);
+            }
+        }
+
+        public int GetHashCode(Triangle obj)
+        {
+            var vertices = obj.Vertices.ToList();
+            if (_rotationIndependent)
+            {
+                vertices = obj.Vertices.OrderBy(v => Math.Abs(v.Position.X) + Math.Abs(v.Position.Y) + Math.Abs(v.Position.Z)).ToList();
+            }
+
+            var alt = 17;
+            alt = alt * 23 + vertices[0].Position.GetHashCode(_precision);
+            alt = alt * 23 + vertices[1].Position.GetHashCode(_precision);
+            alt = alt * 23 + vertices[2].Position.GetHashCode(_precision);
+
+            return alt;
+        }
+    }
+}

--- a/GeometryEx/GeometryEx.csproj
+++ b/GeometryEx/GeometryEx.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="0.8.2" />
+    <PackageReference Include="Hypar.Elements" Version="0.9.1" />
     <PackageReference Include="ParagonClipper" Version="6.4.2" />
     <PackageReference Include="SkeletonNet" Version="1.0.0" />
   </ItemGroup>

--- a/GeometryEx/TriangleEx.cs
+++ b/GeometryEx/TriangleEx.cs
@@ -58,18 +58,13 @@ namespace GeometryEx
         /// <returns>
         /// True if the Triangle vertex positions are AlmostEqual to those of the supplied Triangle.
         /// </returns>
-        public static bool IsEqualTo(this Elements.Geometry.Triangle triangle, 
+        public static bool IsEqualTo(this Elements.Geometry.Triangle triangle,
                                           Elements.Geometry.Triangle thatTriangle)
         {
             var points = triangle.Points();
-            var thosePnts = thatTriangle.Points();
-            var common = 0;
-            points.ForEach(p => common += p.Occurs(thosePnts));
-            if (common == 3)
-            {
-                return true;
-            }
-            return false;
+            var thosePoints = thatTriangle.Points();
+            // If the HashSet Except removes all of the points, then the two triangles were identical.
+            return points.Except(thosePoints).Count() == 0;
         }
 
         /// <summary>
@@ -97,7 +92,7 @@ namespace GeometryEx
         /// True if the Triangle vertex positions are AlmostEqual to those of any Triangle in the supplied List.
         /// </returns>
         public static bool IsListed(this Elements.Geometry.Triangle triangle,
-                                         List<Elements.Geometry.Triangle> triangles)
+                                         IEnumerable<Elements.Geometry.Triangle> triangles)
         {
             foreach (var entry in triangles)
             {
@@ -136,12 +131,11 @@ namespace GeometryEx
         /// <returns>
         /// A Vector3 List.
         /// </returns>
-        public static List<Vector3> Points(this Elements.Geometry.Triangle triangle)
+        public static HashSet<Vector3> Points(this Elements.Geometry.Triangle triangle)
         {
-            var points = new List<Vector3>();
-            triangle.Vertices.ToList().ForEach(v => points.Add(v.Position));
-            return points;
+            return new HashSet<Vector3>(triangle.Vertices.Select(v => v.Position), new Vector3Comparer());
         }
+
 
         /// <summary>
         /// Inserts this Triangle into a new List.
@@ -158,7 +152,7 @@ namespace GeometryEx
         /// <returns></returns>
         public static Polygon ToPolygon(this Elements.Geometry.Triangle triangle)
         {
-            var polygon = new Polygon(triangle.Points());
+            var polygon = new Polygon(triangle.Points().ToList());
             return polygon.IsClockWise() ? polygon.Reversed() : polygon;
         }
     }

--- a/GeometryEx/Vector3Ex.cs
+++ b/GeometryEx/Vector3Ex.cs
@@ -11,7 +11,7 @@ namespace GeometryEx
     public static class Vector3Ex
     {
         /// <summary>
-        /// Find the distance from this point to the line, and output the location 
+        /// Find the distance from this point to the line, and output the location
         /// of the closest point on that line.
         /// Using formula from https://diego.assencio.com/?index=ec3d5dfdfc0b6a0d147a656f0af332bd
         /// </summary>
@@ -19,8 +19,8 @@ namespace GeometryEx
         /// <param name="closestPoint">The point on the line that is closest to this point.</param>
         public static double DistanceTo(this Vector3 point, Line line, out Vector3 closestPoint)
         {
-            var lambda = 
-                (point - line.Start).Dot(line.End - line.Start) / 
+            var lambda =
+                (point - line.Start).Dot(line.End - line.Start) /
                 (line.End - line.Start).Dot(line.End - line.Start);
             if (lambda >= 1)
             {
@@ -46,7 +46,7 @@ namespace GeometryEx
         /// <returns>
         /// A Vector3 point.
         /// </returns>
-        public static Vector3 FarthestFrom (this Vector3 point, List<Vector3> points)
+        public static Vector3 FarthestFrom(this Vector3 point, List<Vector3> points)
         {
             if (points.Count == 0)
             {
@@ -64,7 +64,7 @@ namespace GeometryEx
         public static bool IsHigherThan(this Vector3 thisPoint, Vector3 thatPoint, Vector3 normal)
         {
             var plane = new Plane(thisPoint, normal);
-            if(new Plane(thisPoint, normal).SignedDistanceTo(thatPoint) >= 0.0)
+            if (new Plane(thisPoint, normal).SignedDistanceTo(thatPoint) >= 0.0)
             {
                 return false;
             }


### PR DESCRIPTION
BACKGROUND:
- Roof analysis function was running a bit slow on a mesh which lots of triangles.

DESCRIPTION:
- Use hashsets for testing if a certain point, line, or triangle exists in a list.  By creating reasonable HashCodes that relate to the geometry of the objects we can avoid having to do the actual geometric calculations each time we want to check if somethign already exists.
- upgrade to elements 0.9.1
- Cache the `Edges()` of the mesh, so that we can avoid recomputing them if they have not changed.  I have a couple checks for cache invalidation, but it might not be comprehensive.

TESTING:
- I think working with the RoofAnalysis function using a local version of GeometryEx is probably the best test at the moment.
  
FUTURE WORK:
- Remove the Comparers.cs file which contains comparers that should make it into Elements by version 0.9.2
- There might be a code logic improvement that could be made, but for now data structure speedups have gotten us the speed we need.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/geometryex/9)
<!-- Reviewable:end -->
