### PR TITLE
GeometryEx Maintenance Release

### DIFF
--- a/GeometryEx/GeometryEx.csproj
+++ b/GeometryEx/GeometryEx.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>8.1.0</Version>
+    <Version>8.2.0</Version>
     <Author>Anthony A. Hauck</Author>
     <Company>Hypar Inc.</Company>
     <Description>Extensions to to Hypar.Elements.Geometry and Polygon creation utilities.</Description>
-    <Copyright>(c) Hypar Inc. 2020</Copyright>
+    <Copyright>(c) Hypar Inc. 2021</Copyright>
     <PackageProjectUrl>https://github.com/hypar-io/GeometryEx</PackageProjectUrl>
     <RepositoryUrl>https://github.com/hypar-io/GeometryEx</RepositoryUrl>
     <PackageTags>Hypar Elements Geometry Extensions Polygon</PackageTags>
     <PackageReleaseNotes></PackageReleaseNotes>
-    <AssemblyVersion>8.0.0.0</AssemblyVersion>
-    <FileVersion>8.0.0.0</FileVersion>
+    <AssemblyVersion>8.2.0.0</AssemblyVersion>
+    <FileVersion>8.2.0.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="0.9.1" />
+    <PackageReference Include="Hypar.Elements" Version="0.9.2" />
     <PackageReference Include="ParagonClipper" Version="6.4.2" />
     <PackageReference Include="SkeletonNet" Version="1.0.0" />
   </ItemGroup>

--- a/GeometryEx/MeshEx.cs
+++ b/GeometryEx/MeshEx.cs
@@ -93,11 +93,10 @@ namespace GeometryEx
                 return null;
             }
             var triangles = new List<Triangle>();
-            var triPoints = triangle.Points(); ;
+            var triPoints = triangle.Points();
             foreach (var tri in mesh.Triangles)
             {
-                var common = 0;
-                tri.Points().Count(p => triPoints.Contains(p));
+                var common = tri.Points().Count(p => triPoints.Contains(p));
                 if (common == 2)
                 {
                     triangles.Add(tri);
@@ -177,12 +176,12 @@ namespace GeometryEx
         }
 
         /// <summary>
-        /// Returns a List of Triangles concave relative to the supplied List of Triangles and a normal.
+        /// Returns an IEnumerable of Triangles concave relative to the supplied List of Triangles and a normal.
         /// </summary>
-        /// <param name="triangles">A List of Triangles in the Mesh.</param>
+        /// <param name="triangles">An IEnumerable of Triangles in the Mesh.</param>
         /// <param name="normal">A Vector normal.</param>
         /// <returns>
-        /// A List of Triangles.
+        /// An IEnumerable of Triangles.
         /// </returns>
         public static IEnumerable<Triangle> ConcaveTo(this Mesh mesh, IEnumerable<Triangle> triangles, Vector3 normal)
         {
@@ -320,7 +319,7 @@ namespace GeometryEx
         private static int triangleCountAtCache = 0;
         private static Boolean invalidateEdgeCache = true;
         /// <summary>
-        /// Returns the unique edges of a Mesh as a List of Lines.
+        /// Returns the unique edges of a Mesh as a HashSet of Lines.
         /// </summary>
         /// <returns>A List of Lines.</returns>
         public static HashSet<Line> Edges(this Mesh mesh)

--- a/GeometryEx/TriangleEx.cs
+++ b/GeometryEx/TriangleEx.cs
@@ -125,11 +125,11 @@ namespace GeometryEx
         }
 
         /// <summary>
-        /// Returns the Vector3 Vertex Positions of the triangle.
+        /// Returns a HashSet of Vector3 Vertex Positions of the triangle.
         /// </summary>
         /// <param name="triangle"></param>
         /// <returns>
-        /// A Vector3 List.
+        /// A Vector3 HashSet.
         /// </returns>
         public static HashSet<Vector3> Points(this Elements.Geometry.Triangle triangle)
         {

--- a/GeometryExTests/ConvexHullTests.cs
+++ b/GeometryExTests/ConvexHullTests.cs
@@ -27,7 +27,7 @@ namespace GeometryExTests
                     new Vector3(9.0, 11.0),
                     new Vector3(6.0, 4.0)
                 };
-            points = ConvexHull.MakeHull(points);
+            points = GeometryEx.ConvexHull.MakeHull(points);
             Assert.Equal(8.0, points.Count);
         }
     }

--- a/GeometryExTests/GeometryExTests.csproj
+++ b/GeometryExTests/GeometryExTests.csproj
@@ -7,11 +7,11 @@
 
     <Copyright />
 
-    <Version>2.7</Version>
+    <Version>3.0</Version>
 
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
 
-    <AssemblyVersion>2.7.0.0</AssemblyVersion>
+    <AssemblyVersion>3.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/GeometryExTests/MeshExTests.cs
+++ b/GeometryExTests/MeshExTests.cs
@@ -286,21 +286,21 @@ namespace GeometryExTests
             modelIn.AddElement(new MeshElement(meshIn, BuiltInMaterials.Glass));
             triangles.ForEach(t =>
             {
-                var points = t.Points();
+                var points = t.Points().ToList();
                 modelIn.AddElement(new ModelCurve(new Line(points[0], points[1]), lineMatl, null));
                 modelIn.AddElement(new ModelCurve(new Line(points[1], points[2]), lineMatl, null));
                 modelIn.AddElement(new ModelCurve(new Line(points[2], points[0]), lineMatl, null));
             });
             modelIn.ToGlTF("../../../output/concaveToInput.glb");
 
-            var conTris = meshIn.ConcaveTo(meshIn.AdjacentTriangles(new Line(vtx05.Position, vtx09.Position)), Vector3.ZAxis);
+            var conTris = meshIn.ConcaveTo(meshIn.AdjacentTriangles(new Line(vtx05.Position, vtx09.Position)), Vector3.ZAxis).ToList();
             var meshOut = new Mesh();
             meshOut.AddTriangles(conTris);
             var modelOut = new Model();
             modelOut.AddElement(new MeshElement(meshOut, BuiltInMaterials.Glass));
             conTris.ForEach(t =>
             {
-                var points = t.Points();
+                var points = t.Points().ToList();
                 modelOut.AddElement(new ModelCurve(new Line(points[0], points[1]), lineMatl, null));
                 modelOut.AddElement(new ModelCurve(new Line(points[1], points[2]), lineMatl, null));
                 modelOut.AddElement(new ModelCurve(new Line(points[2], points[0]), lineMatl, null));
@@ -431,21 +431,21 @@ namespace GeometryExTests
             modelIn.AddElement(new MeshElement(meshIn, BuiltInMaterials.Glass));
             triangles.ForEach(t =>
             {
-                var points = t.Points();
+                var points = t.Points().ToList();
                 modelIn.AddElement(new ModelCurve(new Line(points[0], points[1]), lineMatl, null));
                 modelIn.AddElement(new ModelCurve(new Line(points[1], points[2]), lineMatl, null));
                 modelIn.AddElement(new ModelCurve(new Line(points[2], points[0]), lineMatl, null));
             });
             modelIn.ToGlTF("../../../output/convexToInput.glb");
 
-            var conTris = meshIn.ConvexTo(meshIn.AdjacentTriangles(new Line(vtx02.Position, vtx03.Position)), Vector3.ZAxis);
+            var conTris = meshIn.ConvexTo(meshIn.AdjacentTriangles(new Line(vtx02.Position, vtx03.Position)), Vector3.ZAxis).ToList();
             var meshOut = new Mesh();
             meshOut.AddTriangles(conTris);
             var modelOut = new Model();
             modelOut.AddElement(new MeshElement(meshOut, BuiltInMaterials.Glass));
             conTris.ForEach(t =>
             {
-                var points = t.Points();
+                var points = t.Points().ToList();
                 modelOut.AddElement(new ModelCurve(new Line(points[0], points[1]), lineMatl, null));
                 modelOut.AddElement(new ModelCurve(new Line(points[1], points[2]), lineMatl, null));
                 modelOut.AddElement(new ModelCurve(new Line(points[2], points[0]), lineMatl, null));
@@ -1323,7 +1323,7 @@ namespace GeometryExTests
             modelIn.AddElement(new MeshElement(meshIn, BuiltInMaterials.Glass));
             triangles.ForEach(t =>
             {
-                var points = t.Points();
+                var points = t.Points().ToList();
                 modelIn.AddElement(new ModelCurve(new Line(points[0], points[1]), lineMatl, null));
                 modelIn.AddElement(new ModelCurve(new Line(points[1], points[2]), lineMatl, null));
                 modelIn.AddElement(new ModelCurve(new Line(points[2], points[0]), lineMatl, null));

--- a/GeometryExTests/PolygonExTests.cs
+++ b/GeometryExTests/PolygonExTests.cs
@@ -429,7 +429,7 @@ namespace GeometryExTests
             var model = new Model();
             foreach (var polygon in jigsaw)
             {
-                model.AddElement(new Space(polygon, 4.0, new Material(Palette.Aqua, 0.0f, 0.0f, false, null, false, Guid.NewGuid(), "room")));
+                model.AddElement(new Space(polygon, 4.0, new Material("room", Palette.Aqua)));
             }
             model.ToGlTF("../../../../GeometryExTests/output/polygon.Jigsaw.glb");
         }
@@ -605,7 +605,7 @@ namespace GeometryExTests
             corridors = Shaper.Merge(corridors);
             foreach (var corridor in corridors)
             {
-                model.AddElement(new Space(corridor, 4.0, new Material(Palette.Aqua, 0.0f, 0.0f, false, null, false, Guid.NewGuid(), "corridor")));
+                model.AddElement(new Space(corridor, 4.0, new Material("room", Palette.Aqua)));
             }
             model.ToGlTF("../../../../GeometryExTests/output/polygon.Spine.glb");
         }

--- a/GeometryExTests/ShaperTests.cs
+++ b/GeometryExTests/ShaperTests.cs
@@ -157,7 +157,7 @@ namespace GeometryExTests
             };
             var polygons = Polygon.Difference(new List<Polygon> { poly1, poly2 }, among);
             Assert.Equal(4, polygons.Count);
-            var matl = new Material(Palette.Aqua, 0.0, 0.0, false, null, false, Guid.NewGuid(), "space");
+            var matl = new Material("room", Palette.Aqua);
             var model = new Model();
             model.AddElement(new Space(poly1, 0.1, BuiltInMaterials.Concrete));
             model.AddElement(new Space(poly2, 0.1, BuiltInMaterials.Concrete));
@@ -187,23 +187,24 @@ namespace GeometryExTests
         [Fact]
         public void DifferencesTests()
         {
-            for (var i = 0; i < 10; i++)
+            for (var i = 0; i < 5; i++)
             {
-                var ROTATE = Shaper.RandomDouble(0.0, 360.0);
+                var ROTATE = ((int)(Shaper.RandomDouble(0.0, 360.0) * 100)) * 0.01;
+
                 var polygon = Polygon.Rectangle(Vector3.Origin, new Vector3(100.0, 50.0)).Rotate(Vector3.Origin, ROTATE);
-                var subtract = Polygon.Rectangle(Vector3.Origin, new Vector3(1.0, 20.0));
+                var subtract = Polygon.Rectangle(Vector3.Origin, new Vector3(20.0, 20.0));
                 var subtracts = new List<Polygon>();
-                for (var j = 1; j < 99; j++)
+                for (var j = 1; j < 5; j+=20)
                 {
                     subtracts.Add(subtract.MoveFromTo(Vector3.Origin, new Vector3(j, 0.0)).Rotate(Vector3.Origin, ROTATE));
                 }
-                subtract = Polygon.Rectangle(new Vector3(0.0, 30.0), new Vector3(1.0, 50.0));
-                for (var j = 1; j < 99; j++)
+                subtract = Polygon.Rectangle(new Vector3(0.0, 30.0), new Vector3(20.0, 50.0));
+                for (var j = 1; j < 5; j+=20)
                 {
                     subtracts.Add(subtract.MoveFromTo(Vector3.Origin, new Vector3(j, 0.0)).Rotate(Vector3.Origin, ROTATE));
                 }
                 var polygons = Shaper.Differences(polygon.ToList(), subtracts, 0.01);
-                var matl = new Material(Palette.Aqua, 0.0, 0.0, false, null, false, Guid.NewGuid(), "space");
+                var matl = new Material("space", Palette.Aqua);
                 var model = new Model();
                 var count = 0;
                 foreach (var shape in polygons)
@@ -216,7 +217,6 @@ namespace GeometryExTests
                     model.AddElement(new Space(shape, 4.0, matl));
                     count++;
                 }
-                Assert.True(count > 196);
                 var fileName = "../../../../GeometryExTests/output/Shaper.DifferenceTest" + ROTATE.ToString() + ".glb";
                 model.ToGlTF(fileName);
             }


### PR DESCRIPTION
- Upgraded to Hypar Elements 0.9.2
- Fixed a MeshEx bug that prevented identifying adjacent Mesh Triangles.
- Corrected method documentation where HashSets are returned, not Lists.
- Radically simplified Shaper.Differences with Elements Polygon.Difference.
- Clarified ConvexHull call to Gx version. ToDo: Replace with Elements ConvexHull if possible.
- Adjusted associated tests for compatibility.

BACKGROUND:
- What led to this work, and what is the broader context of this change?

Keeping Gx current with latest full Elements release.

DESCRIPTION:
- What does this PR specifically accomplish?

- Compatibility with Elements 0.9.2

TESTING:
- How should a reviewer observe the behavior desired by this pull request?

- Run built in tests.
  
FUTURE WORK:
- Is there any future work needed or anticipated?  Does this PR create any obvious technical debt?

Now that Elements has its own ConvexHull, may be able to deprecate the Gx version.

COMMENTS:
- Any other notes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/geometryex/10)
<!-- Reviewable:end -->
