### PR TITLE
Update Elements reference

### DIFF
--- a/GeometryEx/GeometryEx.csproj
+++ b/GeometryEx/GeometryEx.csproj
@@ -28,7 +28,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hypar.Elements" Version="0.9.2" />
+    <PackageReference Include="Hypar.Elements" Version="0.9.9" />
     <PackageReference Include="ParagonClipper" Version="6.4.2" />
     <PackageReference Include="SkeletonNet" Version="1.0.0" />
   </ItemGroup>

--- a/GeometryExTests/ShaperTests.cs
+++ b/GeometryExTests/ShaperTests.cs
@@ -363,7 +363,7 @@ namespace GeometryExTests
                     new Vector3(6.0, 0.0),
                 };
             var polygon = Shaper.MakePolygon(points);
-            Assert.Equal(7, polygon.Vertices.Count);
+            Assert.Equal(9, polygon.Vertices.Count);
         }
 
         [Fact]


### PR DESCRIPTION
BACKGROUND:
Function using Geometry Ex wasn't working due to serialization issues.

DESCRIPTION:
Updating Function package in the function helped but then It complained about Elements downgrade. To solve this I needed to update Elements reference here.

TESTING:
- Update MakePolygon to reflect Polygon creation behavior in new Elements
- PolygonExTests.ToMesh test fails on new Elements because Polygon.Covers that was changed 6 month ago is not working correctly in this case.
![image](https://user-images.githubusercontent.com/22522160/154446775-71e0072e-1ea3-4507-9d90-78c8d2c3bf5b.png)
  
FUTURE WORK:
Update Elements reference once again when Polygon.Covers is fixed

COMMENTS:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hypar-io/geometryex/12)
<!-- Reviewable:end -->
